### PR TITLE
Add once-off fix for June 2024 RoN update

### DIFF
--- a/CBP-Launcher/App.config
+++ b/CBP-Launcher/App.config
@@ -127,6 +127,12 @@
             <setting name="LogKeepNumber" serializeAs="String">
                 <value>100</value>
             </setting>
+            <setting name="JunePatchFixApplied" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="JunePatchHaveRunBefore" serializeAs="String">
+                <value>False</value>
+            </setting>
         </CBPLauncher.Properties.Settings>
     </userSettings>
   <runtime>

--- a/CBP-Launcher/CBP-Launcher.csproj
+++ b/CBP-Launcher/CBP-Launcher.csproj
@@ -101,7 +101,7 @@
       <HintPath>..\packages\NLog.4.7.11\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="NLogViewer">
-      <HintPath>..\..\NLogViewer\src\NLogViewer\bin\Release\net472\NLogViewer.dll</HintPath>
+      <HintPath>..\..\NLogViewer\src\NLogViewer\obj\Release\net472\NLogViewer.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/CBP-Launcher/Properties/AssemblyInfo.cs
+++ b/CBP-Launcher/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.5.0")]
+[assembly: AssemblyVersion("0.6.6.3")]
 //[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/CBP-Launcher/Properties/Settings.Designer.cs
+++ b/CBP-Launcher/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace CBPLauncher.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.10.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -499,6 +499,30 @@ namespace CBPLauncher.Properties {
             }
             set {
                 this["LogKeepNumber"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool JunePatchFixApplied {
+            get {
+                return ((bool)(this["JunePatchFixApplied"]));
+            }
+            set {
+                this["JunePatchFixApplied"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool JunePatchHaveRunBefore {
+            get {
+                return ((bool)(this["JunePatchHaveRunBefore"]));
+            }
+            set {
+                this["JunePatchHaveRunBefore"] = value;
             }
         }
     }

--- a/CBP-Launcher/Properties/Settings.settings
+++ b/CBP-Launcher/Properties/Settings.settings
@@ -122,5 +122,11 @@
     <Setting Name="LogKeepNumber" Type="System.Int16" Scope="User">
       <Value Profile="(Default)">100</Value>
     </Setting>
+    <Setting Name="JunePatchFixApplied" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="JunePatchHaveRunBefore" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/CBP-Launcher/Skins/ClassicPlus.xaml
+++ b/CBP-Launcher/Skins/ClassicPlus.xaml
@@ -48,6 +48,19 @@
                     <RowDefinition Height="25"/>
                 </Grid.RowDefinitions>
 
+                <!-- hastily assembled fix for RoN's June 2024 patch -->
+                <Button Margin="40, 50, 25, 70" Background="LightSalmon" Visibility="{Binding Path=JunePatchFixButtonVisibility, Converter={StaticResource BoolToVis}}" Command="{Binding JunePatchFixCommand}" BorderThickness="5" BorderBrush="Chocolate" Panel.ZIndex="5">
+                    <Button.Resources>
+                        <Style TargetType="Border">
+                            <Setter Property="CornerRadius" Value="25"/>
+                        </Style>
+                        <BooleanToVisibilityConverter x:Key="BoolToVis" />
+                    </Button.Resources>
+                    <Button.Content>
+                        <TextBlock HorizontalAlignment="Center" Text="PRESS FOR &#x0d;&#x0a;ONCE-OFF &#x0d;&#x0a;FIX FOR &#x0d;&#x0a;JUNE PATCH" FontSize="15" FontWeight="SemiBold"/>
+                    </Button.Content>
+                </Button>
+
                 <!-- way above the logo box -->
                 <Label Content="Checking for updates..." Foreground="#f8f8f8" Margin="0,-30,-15,0" HorizontalAlignment="Center" FontSize="22" FontWeight="SemiBold" Visibility="Hidden">
                     <Label.Effect>
@@ -124,6 +137,7 @@
 
             <!-- tab controls -->
             <Grid Grid.Row="1" Grid.Column="0">
+  
                 <StackPanel Margin="138,5,0,0">
                     <!-- patch notes is default check (looks weird when switching skins but not a big deal) -->
                     <RadioButton Name="CPPN" Content="Patch Notes" Command="{Binding CPTabPatchNotesCommand}" Style="{StaticResource BBRadioButton2}" Height="32" Foreground="LightGray" FontSize="16" FontWeight="SemiBold" Margin="10,6,-10,0" IsChecked="True"/>

--- a/CBP-Launcher/Skins/SpartanV1.xaml
+++ b/CBP-Launcher/Skins/SpartanV1.xaml
@@ -40,6 +40,20 @@
             <Grid Grid.Column="0" Grid.Row="0">
 
                 <!-- counterintuitively, textblock is lighter weight than label, but label has more functionality e.g. horizontalcontentalignment not just horizontalalignment-->
+                
+                <!-- hastily assembled fix for RoN's June 2024 patch -->
+                <Button Grid.Column="0" Grid.Row="2" Margin="50, 150, 50, 60" Background="LightSalmon" Visibility="{Binding Path=JunePatchFixButtonVisibility, Converter={StaticResource BoolToVis}}" Command="{Binding JunePatchFixCommand}" BorderThickness="5" BorderBrush="Chocolate" Panel.ZIndex="5">
+                    <Button.Resources>
+                        <Style TargetType="Border">
+                            <Setter Property="CornerRadius" Value="25"/>
+                        </Style>
+                        <BooleanToVisibilityConverter x:Key="BoolToVis" />
+                    </Button.Resources>
+                    <Button.Content>
+                        <TextBlock HorizontalAlignment="Center" Text="PRESS FOR ONCE-OFF&#x0d;&#x0a;FIX FOR JUNE PATCH" FontSize="15" FontWeight="SemiBold"/>
+                    </Button.Content>
+                </Button>
+
 
                 <!-- left side: top left status text -->
                 <Label Content="Checking for updates..." HorizontalContentAlignment="Center" FontSize="26" HorizontalAlignment="Left" Margin="17,23,17,0" VerticalAlignment="Top" Width="290" Foreground="#FFF0F0F0" FontFamily="Segoe UI Light" Visibility="Hidden"/>

--- a/CBP-Setup-GUI/Properties/AssemblyInfo.cs
+++ b/CBP-Setup-GUI/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.4.0")]
+[assembly: AssemblyVersion("0.6.6.3")]
 //[assembly: AssemblyFileVersion("0.5.0.0")]

--- a/CBPLauncher.sln
+++ b/CBPLauncher.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31005.135
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35004.147
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CBP-Launcher", "CBP-Launcher\CBP-Launcher.csproj", "{81AD6FDC-5DB4-403A-82DD-BBB875795CF4}"
 EndProject
@@ -14,6 +14,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CBP-Setup-GUI.Language", "CBP-Setup-GUI.Language\CBP-Setup-GUI.Language.csproj", "{54B68121-A258-4C03-8322-9F79ABB78005}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CBP-patriots", "CBP-patriots\CBP-patriots.csproj", "{26C0C8DB-354D-4D8E-81F4-4D2269684FEA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Legacy", "Legacy", "{06820D72-30DD-4EFA-A007-E8FD4BAB934F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -152,6 +154,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{07459119-2220-46AB-8131-F3FA92039740} = {06820D72-30DD-4EFA-A007-E8FD4BAB934F}
+		{26C0C8DB-354D-4D8E-81F4-4D2269684FEA} = {06820D72-30DD-4EFA-A007-E8FD4BAB934F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C12EEB22-8A38-4EF8-B0CB-72158E0745D4}


### PR DESCRIPTION
Primarily adds a haphazard compatibility fix for the out-of-the-blue [June 2024 update](https://steamcommunity.com/games/287450/announcements/detail/4255420398665290823).

Misc:
- splits CBP Setup (non-GUI) and patriots off into a legacy folder
- minor housekeeping